### PR TITLE
graceful failure handling for missing authentication strategy

### DIFF
--- a/app/dialogs/sampleAuthDialog.js
+++ b/app/dialogs/sampleAuthDialog.js
@@ -1,6 +1,8 @@
 let auth = require('../services/authenticationService');
 
 module.exports = function (name, bot) {
+    if (!bot.auth)
+        return console.warn('[warning] authentication dialog not initialized. Define AUTH_PROVIDER properties in .env file.');
     bot.dialog(`/${name}`, auth.requireAuthentication([
         function (session) {
             session.send(`hi ${session.privateConversationData.user.displayName}`);

--- a/app/services/authenticationService.js
+++ b/app/services/authenticationService.js
@@ -1,8 +1,10 @@
 let botauth = require('botauth');
-let authStrategy = require(`passport-${process.env.AUTH_PROVIDER_NAME}`).Strategy;
+let tryRequire = require('try-require');
+let auth = tryRequire(`passport-${process.env.AUTH_PROVIDER_NAME}`);
 let session = require('express-session');
 
 let authenticator;
+let authStrategy;
 
 let botAuthOptions = {
     baseUrl: `https://${process.env.WEBSITE_HOSTNAME}`,
@@ -27,6 +29,9 @@ let strategyVerifyFunction = (accessToken, refreshToken, profile, done) => {
 
 module.exports = {
     initialize: (server, bot) => {
+        if (typeof auth === 'undefined') return null;
+
+        authStrategy = auth.Strategy;
         server.use(session({ secret: process.env.BOTAUTH_SECRET }));
         authenticator = new botauth.BotAuthenticator(server, bot, botAuthOptions)
             .provider(process.env.AUTH_PROVIDER_NAME, factory);

--- a/index.js
+++ b/index.js
@@ -22,8 +22,7 @@ server.use(restify.bodyParser());
 server.use(restify.queryParser());
 
 //authentication
-if(process.env.AUTH_PROVIDER_NAME)
-    bot.auth = authenticationService.initialize(server, bot);
+bot.auth = authenticationService.initialize(server, bot);
 
 //recognizers
 utils.getFiles('./app/recognizers')

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "mongodb": "^2.2.26",
     "passport-twitter": "^1.0.4",
     "readdir-enhanced": "^1.4.5",
-    "restify": "^4.1.1"
+    "restify": "^4.1.1",
+    "try-require": "^1.2.1"
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
:wave: hello again!

Ok, so let me know your thoughts about this one. I feel that the basebot would be even radder if it ran out of the box immediately after an `npm install`, `.env` file init, and an `npm start`.

Currently what's in the way of that is an unspecified auth strategy. I went splunking around and deleted the auth sample and removed the authentication service imports in order to get the bot running initially. This is fine, but a 5 minute startup experience for the base bot would be even better 💯 

I am proposing the following code changes: 

+ using a "conditional require" package to prevent the synchronous, eagerly loaded `passport` strategy package in the case that there is no package to require. 

+ returning early from the authentication service module, and the `authDialog` sample. There are printed warnings to assist the user with this for an empathetic DX.

+ `npm start` script command

Happy to make changes / discuss further 😄 

